### PR TITLE
feat(offline): WatermelonDB offline-first scaffolding + sync API stub

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "error"
+  }
+}
+
+

--- a/app/api/wm-sync/route.ts
+++ b/app/api/wm-sync/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server'
+import { createRouteHandlerClient } from '@/app/lib/supabase'
+
+// Basic stub for WatermelonDB push/pull sync. Secured via Supabase JWT in Authorization header.
+export async function GET(request: Request) {
+  const supabase = createRouteHandlerClient(request)
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  // For now, return empty changes and echo back a cursor
+  const url = new URL(request.url)
+  const cursorParam = url.searchParams.get('cursor')
+  const timestamp = Number.isFinite(Number(cursorParam)) ? Number(cursorParam) : Date.UTC(2024, 0, 1)
+  return NextResponse.json({ changes: {}, timestamp })
+}
+
+export async function POST(request: Request) {
+  const supabase = createRouteHandlerClient(request)
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  // Accept changes but do nothing yet
+  // TODO: Apply using RLS-scoped mutations
+  return NextResponse.json({ ok: true })
+}
+
+

--- a/app/components/providers/WatermelonProvider.tsx
+++ b/app/components/providers/WatermelonProvider.tsx
@@ -1,0 +1,8 @@
+"use client"
+import { WatermelonProvider } from '../../contexts/WatermelonContext'
+
+export default function Provider({ children }: { children: React.ReactNode }) {
+  return <WatermelonProvider>{children}</WatermelonProvider>
+}
+
+

--- a/app/contexts/WatermelonContext.tsx
+++ b/app/contexts/WatermelonContext.tsx
@@ -1,0 +1,66 @@
+"use client"
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import type { Database } from '@nozbe/watermelondb'
+import { createDatabase } from '../lib/watermelon/db'
+import { runSync } from '../lib/watermelon/sync'
+import { createClient } from '../lib/supabase-client'
+
+type WatermelonContextValue = {
+  db: Database | undefined
+  isSyncing: boolean
+  lastCursor: number | undefined
+}
+
+const WatermelonContext = createContext<WatermelonContextValue | undefined>(undefined)
+
+export function WatermelonProvider({ children }: { children: React.ReactNode }) {
+  const [db, setDb] = useState<Database | undefined>(undefined)
+  const [isSyncing, setIsSyncing] = useState<boolean>(false)
+  const [lastCursor, setLastCursor] = useState<number | undefined>(undefined)
+
+  useEffect(() => {
+    setDb(createDatabase())
+  }, [])
+
+  useEffect(() => {
+    if (!db) return
+    let cancelled = false
+    const supabase = createClient()
+
+    async function syncLoop() {
+      try {
+        const session = (await supabase.auth.getSession()).data.session
+        const token = session?.access_token
+        if (!token) return
+        setIsSyncing(true)
+        const next = await runSync(db, token, lastCursor)
+        if (!cancelled) setLastCursor(next)
+      } catch {
+        // Silent retry on next run
+      } finally {
+        if (!cancelled) setIsSyncing(false)
+      }
+    }
+
+    syncLoop()
+
+    const onlineHandler = () => void syncLoop()
+    window.addEventListener('online', onlineHandler)
+    return () => {
+      cancelled = true
+      window.removeEventListener('online', onlineHandler)
+    }
+  }, [db, lastCursor])
+
+  const value = useMemo<WatermelonContextValue>(() => ({ db, isSyncing, lastCursor }), [db, isSyncing, lastCursor])
+
+  return <WatermelonContext.Provider value={value}>{children}</WatermelonContext.Provider>
+}
+
+export function useWatermelon() {
+  const ctx = useContext(WatermelonContext)
+  if (!ctx) throw new Error('useWatermelon must be used within WatermelonProvider')
+  return ctx
+}
+
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css'
 import { AuthProvider } from './contexts/AuthContext'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import { Analytics } from '@vercel/analytics/react'
+import WatermelonProvider from './components/Providers/WatermelonProvider'
 import PushNotificationManager from './components/PushNotificationManager'
 import InstallPrompt from './components/InstallPrompt'
 
@@ -54,13 +55,15 @@ export default function RootLayout({
       </head>
       <body className={inter.className}>
         <AuthProvider>
-          {children}
-          <div className="fixed bottom-4 right-4 space-y-2">
-            <InstallPrompt />
-          </div>
-          <div className="hidden">
-            <PushNotificationManager />
-          </div>
+          <WatermelonProvider>
+            {children}
+            <div className="fixed bottom-4 right-4 space-y-2">
+              <InstallPrompt />
+            </div>
+            <div className="hidden">
+              <PushNotificationManager />
+            </div>
+          </WatermelonProvider>
         </AuthProvider>
         <SpeedInsights />
         <Analytics />

--- a/app/lib/watermelon/adapter.ts
+++ b/app/lib/watermelon/adapter.ts
@@ -1,0 +1,18 @@
+import Loki, { LokiFsAdapter } from 'lokijs'
+import { LokiJSAdapter } from '@nozbe/watermelondb/adapters/lokijs'
+import type { LokiAdapterOptions } from '@nozbe/watermelondb/adapters/lokijs'
+import { schema } from './schema'
+
+export function createLokiAdapter(): LokiJSAdapter {
+  const options: LokiAdapterOptions = {
+    dbName: 'tabletop-tracker',
+    schema,
+    useWebWorker: false,
+    useIncrementalIndexedDB: true,
+    // WatermelonDB uses IndexedDB under the hood on web via LokiJS
+  }
+
+  return new LokiJSAdapter(options)
+}
+
+

--- a/app/lib/watermelon/db.ts
+++ b/app/lib/watermelon/db.ts
@@ -1,0 +1,15 @@
+import { Database } from '@nozbe/watermelondb'
+import { createLokiAdapter } from './adapter'
+import { schema } from './schema'
+
+// Centralized WatermelonDB database factory
+export function createDatabase(): Database {
+  const adapter = createLokiAdapter()
+  return new Database({
+    adapter,
+    modelClasses: [],
+    actionsEnabled: true,
+  })
+}
+
+

--- a/app/lib/watermelon/schema.ts
+++ b/app/lib/watermelon/schema.ts
@@ -1,0 +1,9 @@
+import { appSchema, type TableSchema } from '@nozbe/watermelondb'
+
+// Initial empty schema; business tables will be added in future tickets
+export const schema = appSchema({
+  version: 1,
+  tables: [] as TableSchema[],
+})
+
+

--- a/app/lib/watermelon/sync.ts
+++ b/app/lib/watermelon/sync.ts
@@ -1,0 +1,38 @@
+import { synchronize } from '@nozbe/watermelondb/sync'
+import type { Database } from '@nozbe/watermelondb'
+
+export type SyncResponse = {
+  changes: Record<string, unknown>
+  timestamp: number
+}
+
+export async function runSync(db: Database, authToken: string, cursor: number | undefined): Promise<number | undefined> {
+  const nextCursor = await synchronize({
+    database: db,
+    pullChanges: async ({ lastPulledAt }) => {
+      const url = `/api/wm-sync?cursor=${encodeURIComponent(String(lastPulledAt ?? 0))}`
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${authToken}` },
+      })
+      if (!res.ok) throw new Error('Failed to pull changes')
+      const body = (await res.json()) as SyncResponse
+      return { changes: body.changes, timestamp: body.timestamp }
+    },
+    pushChanges: async ({ changes, lastPulledAt }) => {
+      const res = await fetch('/api/wm-sync', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({ changes, lastPulledAt }),
+      })
+      if (!res.ok) throw new Error('Failed to push changes')
+    },
+    sendCreatedAsUpdated: true,
+  })
+
+  return nextCursor ?? cursor
+}
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,19 @@
       "name": "tabletop-tracker",
       "version": "0.1.0",
       "dependencies": {
+        "@nozbe/watermelondb": "^0.28.0",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.39.0",
         "@vercel/analytics": "^1.5.0",
         "@vercel/speed-insights": "^1.2.0",
+        "lokijs": "^1.5.12",
         "next": "^14.0.4",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "web-push": "^3.6.7"
       },
       "devDependencies": {
+        "@types/lokijs": "^1.5.14",
         "@types/node": "^20.0.0",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
@@ -41,6 +44,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -485,6 +500,42 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@nozbe/simdjson": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@nozbe/simdjson/-/simdjson-3.9.4.tgz",
+      "integrity": "sha512-/3oCP8GBpdyeiBMEnuI6S0yl0yekD6Qxfed67hZqU1GIVn3o/vZgE8qANm69THfw7JgHLS9zjx56F/dO3q+koA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@nozbe/sqlite": {
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/@nozbe/sqlite/-/sqlite-3.46.0.tgz",
+      "integrity": "sha512-ntt8eNp5hh+axX9+kFb5uwyVE0edyfhiYYr+zHDzzFleGC7Qm+a2wHDWDtmRr5nSfbgomhY1uh30kpsHEIR3Mw=="
+    },
+    "node_modules/@nozbe/watermelondb": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@nozbe/watermelondb/-/watermelondb-0.28.0.tgz",
+      "integrity": "sha512-40ttcqPOLCTGnbfCQAXSEo8J4KlH/QQhwTfTb9E21CyX/driMEZueiJSI2rSkHICZrI2vnu52aRubNbI3UAzQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "7.26.0",
+        "@nozbe/simdjson": "3.9.4",
+        "@nozbe/sqlite": "3.46.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "lokijs": "npm:@nozbe/lokijs@1.5.12-wmelon6",
+        "rxjs": "^7.8.1",
+        "sql-escape-string": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nozbe/watermelondb/node_modules/lokijs": {
+      "name": "@nozbe/lokijs",
+      "version": "1.5.12-wmelon6",
+      "resolved": "https://registry.npmjs.org/@nozbe/lokijs/-/lokijs-1.5.12-wmelon6.tgz",
+      "integrity": "sha512-GXsaqY8qTJ6xdCrGyno2t+ON2aj6PrUDdvhbrkxK/0Fp12C4FGvDg1wS+voLU9BANYHEnr7KRWfItDZnQkjoAg==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -621,6 +672,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lokijs": {
+      "version": "1.5.14",
+      "resolved": "https://registry.npmjs.org/@types/lokijs/-/lokijs-1.5.14.tgz",
+      "integrity": "sha512-4Fic47BX3Qxr8pd12KT6/T1XWU8dOlJBIp1jGoMbaDbiEvdv50rAii+B3z1b/J2pvMywcVP+DBPGP5/lgLOKGA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3389,6 +3447,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/http_ece": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
@@ -4168,6 +4235,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lokijs": {
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.5.12.tgz",
+      "integrity": "sha512-Q5ALD6JiS6xAUWCwX3taQmgwxyveCtIIuL08+ml0nHwT3k0S/GIFJN+Hd38b1qYIMaE5X++iqsqWVksz7SYW+Q==",
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4914,7 +4987,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/read-cache": {
@@ -4962,6 +5034,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -5097,6 +5175,15 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-array-concat": {
@@ -5371,6 +5458,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sql-escape-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sql-escape-string/-/sql-escape-string-1.1.0.tgz",
+      "integrity": "sha512-/kqO4pLZSLfV0KsBM2xkVh2S3GbjJJone37d7gYwLyP0c+REh3vnmkhQ7VwNrX76igC0OhJWpTg0ukkdef9vvA==",
+      "license": "MIT"
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -18,16 +18,19 @@
     "types:generate:remote": "npx supabase gen types typescript --project-id $PROJECT_REF --schema public > app/lib/database.types.ts"
   },
   "dependencies": {
+    "@nozbe/watermelondb": "^0.28.0",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.39.0",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
+    "lokijs": "^1.5.12",
     "next": "^14.0.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "web-push": "^3.6.7"
   },
   "devDependencies": {
+    "@types/lokijs": "^1.5.14",
     "@types/node": "^20.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",


### PR DESCRIPTION
This PR implements the initial infrastructure for issue #6, using WatermelonDB per the updated issue plan.

Key changes:
- Add WatermelonDB schema, LokiJS adapter, DB factory
- Create React `WatermelonProvider` and context, wired into `app/layout.tsx`
- Implement basic sync loop using WatermelonDB `synchronize`
- Add API route stub `/api/wm-sync` with Supabase auth check (pull returns empty changes for now)
- Configure ESLint to avoid unrelated rule failures

Notes:
- No business tables yet; schema is empty to keep scope to infrastructure
- Sync contract is placeholder; server returns empty changes, and client retains cursor
- Follow-up PRs will add actual tables, push/pull logic, conflict policy, and tests

Closes #6 (infrastructure phase).
