### PR TITLE
feat(sync): implement WatermelonDB pull/push with RLS and LWW (issue #11)

### DIFF
--- a/app/api/wm-sync/route.ts
+++ b/app/api/wm-sync/route.ts
@@ -1,31 +1,238 @@
 import { NextResponse } from 'next/server'
-import { createRouteHandlerClient } from '@/app/lib/supabase'
+import { createClient as createSupabaseJsClient } from '@supabase/supabase-js'
+import type { SyncDatabaseChangeSet } from '@nozbe/watermelondb/sync'
 
-// Basic stub for WatermelonDB push/pull sync. Secured via Supabase JWT in Authorization header.
+type TableName = 'games' | 'players' | 'game_sessions' | 'session_players' | 'game_results'
+
+const TABLES: TableName[] = ['games', 'players', 'game_sessions', 'session_players', 'game_results']
+const TABLES_WITH_SOFT_DELETE: TableName[] = ['games', 'players', 'game_sessions', 'session_players', 'game_results']
+
+function getAuthToken(request: Request): string | undefined {
+  const header = request.headers.get('authorization') || request.headers.get('Authorization')
+  if (!header) return undefined
+  const parts = header.split(' ')
+  if (parts.length === 2 && /^Bearer$/i.test(parts[0])) return parts[1]
+  return undefined
+}
+
+function epochMsToIso(epochMs: number): string {
+  return new Date(epochMs).toISOString()
+}
+
+function isoOrUndefined(epoch: unknown): string | undefined {
+  if (typeof epoch === 'number' && Number.isFinite(epoch)) return epochMsToIso(epoch)
+  return undefined
+}
+
+function createAuthedSupabaseClient(request: Request) {
+  const token = getAuthToken(request)
+  const client = createSupabaseJsClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      global: {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      },
+    }
+  )
+  return { client, token }
+}
+
+function sanitizeRowForTable(table: TableName, row: Record<string, unknown>, serverNowMs: number) {
+  // Only allow known columns per table
+  const baseTimestamps = {
+    created_at: isoOrUndefined(row.created_at) ?? epochMsToIso(serverNowMs),
+    updated_at: isoOrUndefined(row.updated_at) ?? epochMsToIso(serverNowMs),
+  }
+  const softDelete = TABLES_WITH_SOFT_DELETE.includes(table)
+    ? { deleted_at: isoOrUndefined(row.deleted_at) }
+    : {}
+
+  switch (table) {
+    case 'games':
+      return {
+        id: row.id,
+        name: row.name,
+        description: row.description,
+        min_players: row.min_players,
+        max_players: row.max_players,
+        estimated_playtime_minutes: row.estimated_playtime_minutes,
+        complexity_rating: row.complexity_rating,
+        ...baseTimestamps,
+        ...softDelete,
+      }
+    case 'players':
+      return {
+        id: row.id,
+        name: row.name,
+        email: row.email,
+        ...baseTimestamps,
+        ...softDelete,
+      }
+    case 'game_sessions':
+      return {
+        id: row.id,
+        game_id: row.game_id,
+        session_date: row.session_date,
+        location: row.location,
+        notes: row.notes,
+        ...baseTimestamps,
+        ...softDelete,
+      }
+    case 'session_players':
+      return {
+        id: row.id,
+        session_id: row.session_id,
+        player_id: row.player_id,
+        player_order: row.player_order,
+        created_at: isoOrUndefined(row.created_at) ?? epochMsToIso(serverNowMs),
+        // updated_at may exist after migration; include if provided
+        updated_at: isoOrUndefined((row as any).updated_at) ?? epochMsToIso(serverNowMs),
+        ...(TABLES_WITH_SOFT_DELETE.includes('session_players')
+          ? { deleted_at: isoOrUndefined((row as any).deleted_at) }
+          : {}),
+      }
+    case 'game_results':
+      return {
+        id: row.id,
+        session_id: row.session_id,
+        player_id: row.player_id,
+        score: row.score,
+        position: row.position,
+        is_winner: row.is_winner,
+        notes: row.notes,
+        ...baseTimestamps,
+        ...softDelete,
+      }
+  }
+}
+
+// GET: Pull changes
 export async function GET(request: Request) {
-  const supabase = createRouteHandlerClient(request)
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const { client, token } = createAuthedSupabaseClient(request)
+  if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  // For now, return empty changes and echo back a cursor
   const url = new URL(request.url)
   const cursorParam = url.searchParams.get('cursor')
-  const timestamp = Number.isFinite(Number(cursorParam)) ? Number(cursorParam) : Date.UTC(2024, 0, 1)
-  return NextResponse.json({ changes: {}, timestamp })
+  const last = Number.isFinite(Number(cursorParam)) ? Number(cursorParam) : 0
+  const serverNowMs = Date.now()
+  const sinceIso = epochMsToIso(last)
+
+  const changes: SyncDatabaseChangeSet = {}
+
+  for (const table of TABLES) {
+    const created: any[] = []
+    const updated: any[] = []
+    const deleted: string[] = []
+
+    // created: created_at > cursor and not soft-deleted
+    {
+      const createdQuery = client
+        .from(table)
+        .select('*')
+        .gt('created_at', sinceIso)
+        .is('deleted_at', null)
+        .limit(500)
+      const { data } = await createdQuery
+      for (const row of data ?? []) {
+        created.push(row)
+      }
+    }
+
+    // updated: updated_at > cursor and created_at <= cursor and not soft-deleted
+    {
+      const updatedQuery = client
+        .from(table)
+        .select('*')
+        .gt('updated_at', sinceIso)
+        .lte('created_at', sinceIso)
+        .is('deleted_at', null)
+        .limit(500)
+      const { data } = await updatedQuery
+      for (const row of data ?? []) {
+        updated.push(row)
+      }
+    }
+
+    // deleted: ids where deleted_at > cursor
+    if (TABLES_WITH_SOFT_DELETE.includes(table)) {
+      const { data } = await client
+        .from(table)
+        .select('id, deleted_at')
+        .gt('deleted_at', sinceIso)
+        .limit(500)
+      for (const row of data ?? []) {
+        deleted.push(row.id as string)
+      }
+    }
+
+    // Assign into WatermelonDB change set with sanitized rows
+    ;(changes as any)[table] = {
+      created: created.map((r) => sanitizeRowForTable(table, r, serverNowMs)),
+      updated: updated.map((r) => sanitizeRowForTable(table, r, serverNowMs)),
+      deleted,
+    }
+  }
+
+  return NextResponse.json({ changes, timestamp: serverNowMs })
 }
 
+// POST: Push changes
 export async function POST(request: Request) {
-  const supabase = createRouteHandlerClient(request)
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const { client, token } = createAuthedSupabaseClient(request)
+  if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  // Accept changes but do nothing yet
-  // TODO: Apply using RLS-scoped mutations
+  const body = (await request.json().catch(() => undefined)) as
+    | { changes?: SyncDatabaseChangeSet; lastPulledAt?: number }
+    | undefined
+  if (!body || !body.changes || typeof body.changes !== 'object') {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+  }
+
+  const serverNowMs = Date.now()
+
+  for (const table of TABLES) {
+    const tableChanges = (body.changes as any)[table] as
+      | { created?: Record<string, unknown>[]; updated?: Record<string, unknown>[]; deleted?: string[] }
+      | undefined
+    if (!tableChanges) continue
+
+    const created = Array.isArray(tableChanges.created) ? tableChanges.created : []
+    const updated = Array.isArray(tableChanges.updated) ? tableChanges.updated : []
+    const deleted = Array.isArray(tableChanges.deleted) ? tableChanges.deleted : []
+
+    // Created: upsert with client-provided UUIDs, set timestamps to serverNow if missing
+    if (created.length > 0) {
+      const rows = created
+        .map((row) => sanitizeRowForTable(table, row, serverNowMs))
+        .filter((r) => r && typeof (r as any).id === 'string')
+      if (rows.length > 0) {
+        await client.from(table).upsert(rows, { onConflict: 'id' })
+      }
+    }
+
+    // Updated: LWW - only apply if server.updated_at < client.updated_at
+    for (const row of updated) {
+      const sanitized = sanitizeRowForTable(table, row, serverNowMs) as any
+      const id = sanitized.id as string | undefined
+      const clientUpdatedIso = isoOrUndefined((row as any).updated_at) || epochMsToIso(serverNowMs)
+      if (!id) continue
+
+      await client
+        .from(table)
+        .update(sanitized)
+        .eq('id', id)
+        .lt('updated_at', clientUpdatedIso)
+    }
+
+    // Deleted: soft-delete by setting deleted_at = serverNow
+    if (deleted.length > 0 && TABLES_WITH_SOFT_DELETE.includes(table)) {
+      await client
+        .from(table)
+        .update({ deleted_at: epochMsToIso(serverNowMs) })
+        .in('id', deleted as string[])
+    }
+  }
+
   return NextResponse.json({ ok: true })
 }
-
-

--- a/app/lib/watermelon/schema.ts
+++ b/app/lib/watermelon/schema.ts
@@ -54,6 +54,8 @@ export const schema = appSchema({
         { name: 'player_id', type: 'string', isIndexed: true },
         { name: 'player_order', type: 'number' },
         { name: 'created_at', type: 'number' },
+        { name: 'updated_at', type: 'number' },
+        { name: 'deleted_at', type: 'number', isOptional: true },
       ],
     }),
 
@@ -74,5 +76,3 @@ export const schema = appSchema({
     }),
   ],
 })
-
-

--- a/app/lib/watermelon/transform.ts
+++ b/app/lib/watermelon/transform.ts
@@ -1,0 +1,185 @@
+import type { SyncDatabaseChangeSet } from '@nozbe/watermelondb/sync'
+import { schema } from './schema'
+
+export type TableName = 'games' | 'players' | 'game_sessions' | 'session_players' | 'game_results'
+
+type WatermelonSchema = { tables: Array<{ name: string; columns: Array<{ name: string }> }> }
+const wmTables = (schema as unknown as WatermelonSchema).tables ?? []
+const SOFT_DELETE_SET = new Set<TableName>(
+  wmTables
+    .filter((t) => (t.columns || []).some((c) => c.name === 'deleted_at'))
+    .map((t) => t.name as TableName)
+)
+
+export function tableHasSoftDelete(table: TableName): boolean {
+  return SOFT_DELETE_SET.has(table)
+}
+
+export function epochMsToIso(epochMs: number): string {
+  return new Date(epochMs).toISOString()
+}
+
+export function isoFromEpoch(epoch: unknown): string | undefined {
+  if (typeof epoch === 'number' && Number.isFinite(epoch)) return epochMsToIso(epoch)
+  return undefined
+}
+
+export function sanitizeRowForTable(
+  table: TableName,
+  row: Record<string, unknown>,
+  serverNowMs: number
+): Record<string, unknown> {
+  const baseTimestamps = {
+    created_at: isoFromEpoch(row.created_at) ?? epochMsToIso(serverNowMs),
+    updated_at: isoFromEpoch(row.updated_at) ?? epochMsToIso(serverNowMs),
+  }
+  const withSoftDelete = tableHasSoftDelete(table)
+    ? { deleted_at: isoFromEpoch(row.deleted_at) }
+    : {}
+
+  switch (table) {
+    case 'games':
+      return {
+        id: row.id,
+        name: row.name,
+        description: row.description,
+        min_players: row.min_players,
+        max_players: row.max_players,
+        estimated_playtime_minutes: row.estimated_playtime_minutes,
+        complexity_rating: row.complexity_rating,
+        ...baseTimestamps,
+        ...withSoftDelete,
+      }
+    case 'players':
+      return {
+        id: row.id,
+        name: row.name,
+        email: row.email,
+        ...baseTimestamps,
+        ...withSoftDelete,
+      }
+    case 'game_sessions':
+      return {
+        id: row.id,
+        game_id: row.game_id,
+        session_date: row.session_date,
+        location: row.location,
+        notes: row.notes,
+        ...baseTimestamps,
+        ...withSoftDelete,
+      }
+    case 'session_players':
+      return {
+        id: row.id,
+        session_id: row.session_id,
+        player_id: row.player_id,
+        player_order: row.player_order,
+        created_at: isoFromEpoch(row.created_at) ?? epochMsToIso(serverNowMs),
+        updated_at: isoFromEpoch(getField(row, 'updated_at')) ?? epochMsToIso(serverNowMs),
+        ...(tableHasSoftDelete('session_players')
+          ? { deleted_at: isoFromEpoch(getField(row, 'deleted_at')) }
+          : {}),
+      }
+    case 'game_results':
+      return {
+        id: row.id,
+        session_id: row.session_id,
+        player_id: row.player_id,
+        score: row.score,
+        position: row.position,
+        is_winner: row.is_winner,
+        notes: row.notes,
+        ...baseTimestamps,
+        ...withSoftDelete,
+      }
+  }
+}
+
+export function buildChangeSet(
+  tables: Record<
+    TableName,
+    { created: Record<string, unknown>[]; updated: Record<string, unknown>[]; deleted: string[] }
+  >,
+  serverNowMs: number
+): SyncDatabaseChangeSet {
+  const out: Record<string, { created: Record<string, unknown>[]; updated: Record<string, unknown>[]; deleted: string[] }> = {}
+  for (const table of Object.keys(tables) as TableName[]) {
+    const { created, updated, deleted } = tables[table]
+    out[table] = {
+      created: created.map((r) => sanitizeRowForTable(table, r, serverNowMs)),
+      updated: updated.map((r) => sanitizeRowForTable(table, r, serverNowMs)),
+      deleted,
+    }
+  }
+  return out as SyncDatabaseChangeSet
+}
+
+export type PushOps = {
+  upserts: Partial<Record<TableName, Record<string, unknown>[]>>
+  updates: Partial<
+    Record<TableName, { id: string; row: Record<string, unknown>; clientUpdatedIso: string }[]>
+  >
+  deletes: Partial<Record<TableName, string[]>>
+}
+
+export function splitPushChanges(
+  changes: SyncDatabaseChangeSet,
+  serverNowMs: number
+): PushOps {
+  const upserts: PushOps['upserts'] = {}
+  const updates: PushOps['updates'] = {}
+  const deletes: PushOps['deletes'] = {}
+
+  for (const table of Object.keys(changes) as TableName[]) {
+    const raw = (changes as unknown as Record<string, unknown>)[table]
+    const obj = (raw && typeof raw === 'object') ? (raw as Record<string, unknown>) : undefined
+
+    const createdUnknown = obj?.created
+    const updatedUnknown = obj?.updated
+    const deletedUnknown = obj?.deleted
+
+    const created = isRawRecordArray(createdUnknown) ? createdUnknown : []
+    const updatedRows = isRawRecordArray(updatedUnknown) ? updatedUnknown : []
+    const deletedIds = isStringArray(deletedUnknown) ? deletedUnknown : []
+
+    if (created.length > 0) {
+      upserts[table] = created
+        .map((row) => sanitizeRowForTable(table, row, serverNowMs))
+        .filter((r) => typeof r['id'] === 'string')
+    }
+
+    if (updatedRows.length > 0) {
+      updates[table] = updatedRows
+        .map((row) => {
+          const sanitized = sanitizeRowForTable(table, row, serverNowMs)
+          const idVal = sanitized['id']
+          const clientUpdatedIso = isoFromEpoch(getField(row, 'updated_at')) ?? epochMsToIso(serverNowMs)
+          if (typeof idVal !== 'string') return undefined
+          return { id: idVal, row: sanitized, clientUpdatedIso }
+        })
+        .filter((v): v is { id: string; row: Record<string, unknown>; clientUpdatedIso: string } => !!v)
+    }
+
+    if (deletedIds.length > 0) {
+      deletes[table] = deletedIds
+    }
+  }
+
+  return { upserts, updates, deletes }
+}
+
+// Helpers
+type RawRecord = Record<string, unknown>
+
+function isRawRecordArray(val: unknown): val is RawRecord[] {
+  return Array.isArray(val) && val.every((v) => v !== null && typeof v === 'object' && !Array.isArray(v))
+}
+
+function isStringArray(val: unknown): val is string[] {
+  return Array.isArray(val) && val.every((v) => typeof v === 'string')
+}
+
+function getField<T = unknown>(row: RawRecord, key: string): T | undefined {
+  const value = row[key]
+  return (value as T | undefined)
+}

--- a/supabase/migrations/20240901000000_add_soft_deletes_and_timestamps.sql
+++ b/supabase/migrations/20240901000000_add_soft_deletes_and_timestamps.sql
@@ -1,0 +1,22 @@
+-- Add soft deletes (deleted_at) and ensure updated_at exists across tables
+
+-- Add deleted_at to all domain tables
+ALTER TABLE games ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE players ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE game_sessions ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE session_players ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE game_results ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;
+
+-- Ensure updated_at exists on session_players (others already created in initial schema)
+ALTER TABLE session_players ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW();
+
+-- Indexes for soft delete filters
+CREATE INDEX IF NOT EXISTS idx_games_deleted_at ON games(deleted_at);
+CREATE INDEX IF NOT EXISTS idx_players_deleted_at ON players(deleted_at);
+CREATE INDEX IF NOT EXISTS idx_game_sessions_deleted_at ON game_sessions(deleted_at);
+CREATE INDEX IF NOT EXISTS idx_session_players_deleted_at ON session_players(deleted_at);
+CREATE INDEX IF NOT EXISTS idx_game_results_deleted_at ON game_results(deleted_at);
+
+-- Trigger for updating updated_at on session_players
+CREATE TRIGGER update_session_players_updated_at BEFORE UPDATE ON session_players
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
Implements server sync endpoints and DB support for WatermelonDB.

- GET /api/wm-sync: returns created/updated/deleted per table since cursor, scoped by RLS
- POST /api/wm-sync: applies creates, updates (LWW), and soft-deletes
- Migration: add deleted_at to all tables, add updated_at to session_players, plus indexes and trigger
- Watermelon schema: include updated_at/deleted_at on session_players

Acceptance:
- Pull returns proper change sets for all five tables
- Push applies creates/updates/deletes with LWW under RLS

Manual test guidance:
1) Create records offline, then push
2) Modify on server, then pull
3) Delete on client, push; verify soft-deleted

Closes #11.